### PR TITLE
Add hotel room block information to travel page

### DIFF
--- a/pages/attend/travel.md
+++ b/pages/attend/travel.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Travel
-description: 
+description:
 menubar: attend
 permalink: attend/travel/
 toc_title: Travel Information
@@ -11,20 +11,40 @@ set_last_modified: true
 
 ## Hotel
 
-We are currently working on finalizing rooms blocks; more information to be released mid-June 2026.
+The conference will be held at the [San Jose Marriott](https://www.marriott.com/en-us/hotels/sjcsj-san-jose-marriott/overview/). Our room block is at the Hyatt Place San Jose/Downtown, a 5 minute walk (0.2 miles) from the venue.
+
+[Hyatt Place San Jose/Downtown](https://www.hyatt.com/en-US/hotel/california/hyatt-place-san-jose-downtown/sjczj) <br>
+282 Almaden Boulevard, San Jose, CA 95113 ([Google Maps](https://www.google.com/maps/search/?api=1&query=Hyatt+Place+San+Jose%2FDowntown%2C+282+Almaden+Boulevard%2C+San+Jose%2C+CA+95113))
+
+### Room Reservations
+
+We would greatly appreciate you staying in the conference room block. Maintaining reasonable conference registration rates requires that we fill the hotel room reservation block.
+
+Please plan to arrive on Sunday, October 18, 2026. The conference starts early Monday morning, and we are planning an informal networking event on Sunday evening.
+
+The room block covers Sunday, Monday, and Tuesday nights (October 18-20), with checkout on Wednesday, October 21. Limited additional rooms are available for attendees arriving Saturday, October 17 or checking out Thursday, October 22. All of these nights can be booked through the reservation links below.
+
+The deadline to reserve a room in the conference room block is September 25, 2026, but the room block may fill up before the deadline, so we encourage attendees to reserve a room as soon as possible.
+
+* [Attendee reservation link](https://www.hyatt.com/events/en-US/group-booking/SJCZJ/G-URAT): $259/night + taxes
+* [Government rate reservation link](https://www.hyatt.com/events/en-US/group-booking/SJCZJ/G-URGO): at check-in, guests will be required to provide eligible ID.
+
+If you plan to arrive early or stay late, we encourage you to make your room reservation early. Blocked rooms for those dates are limited, and weekends and overlapping conferences in the area may limit non-block availability.
+
+If you have questions about reservations, please contact us at [usrse26-conference@us-rse.org](mailto:usrse26-conference@us-rse.org).
 
 
 ## Food
 
-The conference registration fee includes lunch as well as coffee breaks on Monday, Tuesday, and Wednesday.  
+The conference registration fee includes lunch as well as coffee breaks on Monday, Tuesday, and Wednesday.
 
-Additional evening reception events with some food and drinks will also be held and included in the registration fee. 
+Additional evening reception events with some food and drinks will also be held and included in the registration fee.
 
 
 ## Getting to San Jose
 
-* The San Jose International Airport (SJC) is about 4 miles (about 15 minutes by car, depending on traffic) from the conference hotel.
-* The San Francisco International Airport (SFO) is about 36 miles (45-75+ minutes by car, depending on traffic) from the conference hotel.
+* The San Jose International Airport (SJC) is about 4 miles (about 15 minutes by car, depending on traffic) from downtown San Jose.
+* The San Francisco International Airport (SFO) is about 36 miles (45-75+ minutes by car, depending on traffic) from downtown San Jose.
 * The Oakland International Airport (OAK) is about 36 miles (45-75+ minutes by car, depending on traffic) from San Jose and may offer less expensive flights from some parts of the country.
 
 ## Transportation around the Bay


### PR DESCRIPTION
The room block at the Hyatt Place San Jose/Downtown is now open. This replaces the "finalizing rooms blocks" placeholder in the Hotel section of the travel page.

The structure follows the USRSE'25 travel page.

## Details

- **Hotel:** Hyatt Place San Jose/Downtown, 282 Almaden Boulevard, with a Google Maps link. The conference venue is the San Jose Marriott, a 5 minute walk (0.2 miles) away, so the page states the venue and the room block hotel separately.
- **Nights:** Sunday through Tuesday (October 18-20), checkout Wednesday, October 21. Limited additional rooms for Saturday, October 17 arrival or Thursday, October 22 checkout, bookable through the same portals.
- **Deadline:** September 25, 2026, with a note that the block may fill sooner.
- **Links:** attendee portal at $259/night + taxes, and the government rate portal, which notes that eligible ID is required at check-in. No government nightly rate is listed, so attendees see it in the portal.

The SJC and SFO airport bullets now measure from "downtown San Jose". They previously read "from the conference hotel", which was written when the hotel and venue were assumed to be the same building. The distances are unchanged.

## Verification

Site builds cleanly with Jekyll in Docker, and the Hotel section renders as expected.

Draft pending a check that both Hyatt booking portals land on the correct block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)