### PR TITLE
Update/sponsor logos layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,18 @@ docker run --rm -it -p 4000:4000 \
 Change a source file, such as `index.html` for example, and save the changes. You will see Jekyll automatically regenerate the site,
 after which you can reload the page in your browser to see the rendered changes.
 
+## Adding logos to the website
+
+There is an `_include` file, `add-sponsor-logo.html`, that can be used to add a
+sponsor's logo anywhere on the website.
+You can use the function by calling:
+`{% include add-sponsor-logo.html sponsor_url="some_url" logo_file="logo-filename.png" logo_alt="Some alt text for users" %}`
+See the include file for details on the variable names.
+The logo files need to be added to the `assets/img/sponsor-logos/` directory.
+
+### Logos on the main page
+
+To add the sponsor logos to the main page, follow the same directions as above,
+but make sure the include call is in the correct tier section for the sponsor.
+For example, UIUC is a platinum sponsor, so they are added to the
+`<div class="row sponsor-platinum ...>` block.

--- a/_includes/add-sponsor-logo.html
+++ b/_includes/add-sponsor-logo.html
@@ -1,0 +1,13 @@
+<!-- Add sponsor logo -->
+ <!-- 
+    sponsor_url: The URL of the sponsor's website, e.g. "https://globus.org"
+    logo_file: The file name of the sponsor's logo, e.g. "uiuc.png"
+    logo_alt: The alternative text for the sponsor's logo, e.g. "UIUC logo"
+ -->
+<div class="col sponsor-logo">
+    <a href="{{ include.sponsor_url }}">
+        <img
+            src="{{ site.baseurl }}/assets/img/sponsor-logos/{{ include.logo_file }}"
+            alt="{{ include.logo_alt }}" />
+    </a>
+</div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -12283,25 +12283,31 @@ article > a:visited:hover {
     margin-bottom: 2rem;
 }
 
- .sponsor-logo img {
+/* Default sponsor logo styles */
+.sponsor-logo img {
     display: block;
     margin: 0 auto;
     object-fit: contain;
-    width:  clamp(80px, 10vw, 100px);
-    height: clamp(48px, 6vw, 60px);
-}
-
-.sponsor-logo.platinum img {
-    width:  clamp(340px, 30vw, 420px);
-    height: clamp(160px, 20vw, 200px);
-}
-
-.sponsor-logo.gold img {
     width:  clamp(220px, 20vw, 300px);
     height: clamp(100px, 15vw, 140px);
 }
 
-.sponsor-logo.silver img {
+.sponsor-platinum .sponsor-logo img {
+    width:  clamp(340px, 30vw, 420px);
+    height: clamp(160px, 20vw, 200px);
+}
+
+.sponsor-gold .sponsor-logo img {
+    width:  clamp(220px, 20vw, 300px);
+    height: clamp(100px, 15vw, 140px);
+}
+
+.sponsor-silver .sponsor-logo img {
     width:  clamp(140px, 15vw, 180px);
     height: clamp(65px,  7vw,  90px);
+}
+
+.sponsor-bronze .sponsor-logo img {
+    width:  clamp(100px, 10vw, 120px);
+    height: clamp(50px, 10vw, 60px);
 }

--- a/index.html
+++ b/index.html
@@ -38,11 +38,6 @@ cards: home
 
   <div class="row sponsor-platinum row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center align-items-center">
     {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
   </div>
 </section>
 
@@ -51,37 +46,28 @@ cards: home
 
   <div class="row sponsor-gold row-cols-2 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center align-items-center">
     {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
   </div>
 </section>
 
+<!--
 <section class="text-center pt-4">
   <h3>Silver Sponsors</h3>
 
   <div class="row sponsor-silver row-cols-2 row-cols-md-3 row-cols-lg-4 g-4 justify-content-center align-items-center">
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    Add Silver sponsors here
   </div>
 </section>
+-->
 
+<!--
 <section class="text-center pt-4">
   <h3>Bronze Sponsors</h3>
 
   <div class="row sponsor-bronze row-cols-2 row-cols-md-4 row-cols-lg-5 g-4 justify-content-center align-items-center">
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
-    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
+    Add Bronze sponsors here
   </div>
 </section>
+-->
 
 <h1 style="text-align: center;">Conference News &amp; Updates</h1>
 <hr>

--- a/index.html
+++ b/index.html
@@ -33,29 +33,141 @@ cards: home
   <h2 style="margin: 0; color: white;">Conference Sponsors</h2>
 </div>
 
-<section style="text-align: center; clear: both; padding-top: 2rem;">
+<section class="text-center pt-4">
   <h3>Platinum Sponsors</h3>
 
-  <div class="sponsor-logo platinum">
-    <a href="https://illinois.edu/" style="display: inline-block;">
-      <img
-        src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png"
-        alt="UIUC logo"
-      />
-    </a>
+  <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center align-items-center">
+    <div class="col sponsor-logo platinum">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo platinum">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo platinum">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo platinum">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo platinum">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo platinum">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
   </div>
 </section>
 
-<section style="text-align: center; clear: both; padding-top: 2rem;">
+<section class="text-center pt-4">
   <h3>Gold Sponsors</h3>
 
-  <div class="sponsor-logo gold">
-    <a href="https://globus.org/" style="display: inline-block;">
-      <img
-        src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png"
-        alt="Globus logo"
-      />
-    </a>
+  <div class="row row-cols-2 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center align-items-center">
+    <div class="col sponsor-logo gold">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo gold">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo gold">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo gold">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo gold">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="text-center pt-4">
+  <h3>Silver Sponsors</h3>
+
+  <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-4 justify-content-center align-items-center">
+    <div class="col sponsor-logo silver">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo silver">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo silver">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo silver">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo silver">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="text-center pt-4">
+  <h3>Bronze Sponsors</h3>
+
+  <div class="row row-cols-2 row-cols-md-4 row-cols-lg-5 g-4 justify-content-center align-items-center">
+    <div class="col sponsor-logo bronze">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo bronze">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo bronze">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo bronze">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo bronze">
+      <a href="https://globus.org/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
+      </a>
+    </div>
+    <div class="col sponsor-logo bronze">
+      <a href="https://illinois.edu/">
+        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
+      </a>
+    </div>
   </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -36,138 +36,50 @@ cards: home
 <section class="text-center pt-4">
   <h3>Platinum Sponsors</h3>
 
-  <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center align-items-center">
-    <div class="col sponsor-logo platinum">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo platinum">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo platinum">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo platinum">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo platinum">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo platinum">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
+  <div class="row sponsor-platinum row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center align-items-center">
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
   </div>
 </section>
 
 <section class="text-center pt-4">
   <h3>Gold Sponsors</h3>
 
-  <div class="row row-cols-2 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center align-items-center">
-    <div class="col sponsor-logo gold">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo gold">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo gold">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo gold">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo gold">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
+  <div class="row sponsor-gold row-cols-2 row-cols-md-2 row-cols-lg-3 g-4 justify-content-center align-items-center">
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
   </div>
 </section>
 
 <section class="text-center pt-4">
   <h3>Silver Sponsors</h3>
 
-  <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-4 justify-content-center align-items-center">
-    <div class="col sponsor-logo silver">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo silver">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo silver">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo silver">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo silver">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
+  <div class="row sponsor-silver row-cols-2 row-cols-md-3 row-cols-lg-4 g-4 justify-content-center align-items-center">
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
   </div>
 </section>
 
 <section class="text-center pt-4">
   <h3>Bronze Sponsors</h3>
 
-  <div class="row row-cols-2 row-cols-md-4 row-cols-lg-5 g-4 justify-content-center align-items-center">
-    <div class="col sponsor-logo bronze">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo bronze">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo bronze">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo bronze">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo bronze">
-      <a href="https://globus.org/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/globus.png" alt="Globus logo" />
-      </a>
-    </div>
-    <div class="col sponsor-logo bronze">
-      <a href="https://illinois.edu/">
-        <img src="{{ site.baseurl }}/assets/img/sponsor-logos/uiuc.png" alt="UIUC logo" />
-      </a>
-    </div>
+  <div class="row sponsor-bronze row-cols-2 row-cols-md-4 row-cols-lg-5 g-4 justify-content-center align-items-center">
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://globus.org/" logo_file="globus.png" logo_alt="Globus logo" %}
+    {% include add-sponsor-logo.html sponsor_url="https://illinois.edu/" logo_file="uiuc.png" logo_alt="UIUC logo" %}
   </div>
 </section>
 


### PR DESCRIPTION
Updates sponsor logo layout on the main page to fix single logos per row

## Description
Updates the layout for the sponsors' logos on the front page. This makes it so that multiple logos can be on the same row of the sections. It is set up so that the the platinum and gold have less logos per row, since the logos are larger. Please provide any feedback about the choices of these limits, the size of the logos, or otherwise.

#### !!! Before merging anything, their are several duplicates at the moment to see the way the layout will look. These need to be removed before any merge happens. Since we only have UIUC (platinum) and Globus (gold) at the moment, we also need to comment out the silver and bronze sections until we get sponsors in those tiers. !!!!

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] (Committee Chairs Only) I have posted the link for the PR to ask for content reviewers
- [x] I have previewed changes locally
- [x] I have updated the README.md if necessary

cc **ADD GITHUB HANDLES HERE**
@mrmundt @sandragesing @jsubida 